### PR TITLE
Add pypi publishing pipeline

### DIFF
--- a/.github/workflows/publish-broker.yml
+++ b/.github/workflows/publish-broker.yml
@@ -1,7 +1,9 @@
 name: Release Broker
 
 on:
-  push
+  push:
+    tags:
+      - "*"
 
 jobs:
   build_python_wheels:

--- a/.github/workflows/publish-broker.yml
+++ b/.github/workflows/publish-broker.yml
@@ -1,0 +1,79 @@
+name: Release Broker
+
+on:
+  push
+
+jobs:
+  build_python_wheels:
+    name: Build wheels ${{ matrix.os }} - python ${{ matrix.python }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11]
+        python: ["3.10", "3.11"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.18.1'
+
+      - name: Install poetry
+        run:
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Build wheels
+        run: |
+          export PATH="/Users/runner/.local/bin:$PATH"
+          cp -r broker dagorama-broker/broker
+          cd dagorama-broker
+          poetry install
+          poetry build
+      - name: List wheels
+        run: |
+          cd dagorama-broker/dist
+          ls -ls
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dagorama-broker/dist/*.whl
+
+  publish_python_package:
+    name: Publish python package
+    needs: [build_python_wheels]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dagorama-broker/dist
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install poetry
+        run:
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Build sdist static artifact
+        run: |
+          cp -r broker dagorama-broker/broker
+          cd dagorama-broker
+          poetry install
+          poetry build --format sdist
+      - name: Publish
+        run: |
+          cd dagorama-broker
+          poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Release Python Package
 
 on:
-  push
+  push:
+    tags:
+      - "*"
 
 jobs:
   publish_python_package:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Release Python Package
+
+on:
+  push
+
+jobs:
+  publish_python_package:
+    name: Publish python package
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install poetry
+        run:
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Build sdist static artifact
+        run: |
+          poetry install
+          poetry build
+      - name: Publish
+        run: |
+          poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           export PATH="/Users/runner/.local/bin:$PATH"
           poetry install
+          cp broker ./dagorama-broker
           poetry run pip install -e ./dagorama-broker
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           export PATH="/Users/runner/.local/bin:$PATH"
           poetry install
-          cp broker ./dagorama-broker
+          cp -r broker ./dagorama-broker
           poetry run pip install -e ./dagorama-broker
 
       - name: Run tests

--- a/dagorama-broker/build.py
+++ b/dagorama-broker/build.py
@@ -1,0 +1,77 @@
+from distutils.command.build_ext import build_ext
+from distutils.core import Distribution
+from distutils.errors import (CCompilerError, CompileError, DistutilsExecError,
+                              DistutilsPlatformError)
+from distutils.extension import Extension
+from os import chmod, stat
+from pathlib import Path
+from shutil import copyfile
+from subprocess import run
+
+
+class GoExtension(Extension):
+    def __init__(self, name, path):
+        super().__init__(name, sources=[])
+        self.path = path
+
+
+extensions = [
+    GoExtension(
+        "dagorama_broker.assets.dagorama",
+        # Assume we have temporarily copied over the broker folder into our current path
+        # We don't want it to be referenced in the actual parent library, since we need to bundle
+        # it alongside the python project in sdist in case clients need to build from source
+        # when wheels aren't available.
+        "./broker",
+    )
+]
+
+
+class BuildFailed(Exception):
+    pass
+
+
+class GoExtensionBuilder(build_ext):
+    def run(self):
+        try:
+            build_ext.run(self)
+        except (DistutilsPlatformError, FileNotFoundError):
+            raise BuildFailed("File not found. Could not compile extension.")
+
+    def build_extension(self, ext):
+        try:
+            if isinstance(ext, GoExtension):
+                extension_root = Path(__file__).parent.resolve() / ext.path
+                ext_path = self.get_ext_fullpath(ext.name)
+                result = run(["go", "build", "-o", str(Path(ext_path).absolute())], cwd=extension_root)
+                if result.returncode != 0:
+                    raise CompileError("Go build failed")
+            else:
+                build_ext.build_extension(self, ext)
+        except (CCompilerError, DistutilsExecError, DistutilsPlatformError, ValueError):
+            raise BuildFailed('Could not compile C extension.')
+
+
+def build(setup_kwargs):
+    distribution = Distribution({"name": "python_ctypes", "ext_modules": extensions})
+    distribution.package_dir = "python_ctypes"
+
+    cmd = GoExtensionBuilder(distribution)
+    cmd.ensure_finalized()
+    cmd.run()
+
+    # This is somewhat of a hack with go executables; this pipeline will package
+    # them as .so files but they aren't actually built libraries. We maintain
+    # this convention only for the ease of plugging in to poetry and distutils that
+    # use this suffix to indicate the build architecture and run on the
+    # correct downstream client OS.
+    for output in cmd.get_outputs():
+        relative_extension = Path(output).relative_to(cmd.build_lib)
+        copyfile(output, relative_extension)
+        mode = stat(relative_extension).st_mode
+        mode |= (mode & 0o444) >> 2
+        chmod(relative_extension, mode)
+
+
+if __name__ == "__main__":
+    build({})

--- a/dagorama-broker/pyproject.toml
+++ b/dagorama-broker/pyproject.toml
@@ -13,3 +13,8 @@ python = "^3.10"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.build]
+# Custom builder until Poetry expands their build plugin support: https://github.com/python-poetry/poetry/issues/2740
+generate-setup-file = false
+script = "build.py"


### PR DESCRIPTION
Publish two separate libraries to pypi, one for the core code that's expected to work on all worker and the other for integrations that require the python package to launch the golang broker.

The broker library also builds basic wheels for OSX and Linux.