### PR TITLE
Add custom port arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ To launch a worker function, install the python package in your virtualenv and r
 worker [--include-queue {queue}] [--exclude-queue {queue}] [--toleration {toleration}]
 ```
 
+This worker application supports the following env variables:
+
+`DAGORAMA_HOST` - (optional) Host for the dagorama broker
+`DAGORAMA_PORT` - (optional) Port for the dagorama broker
+
 ## Production Deployment (WIP)
 
 Outside of local testing, you probably won't want to run the workers on your same machine. Instead you'll want to distribute them across multiple machines. In this setup we recommend:

--- a/broker.Dockerfile
+++ b/broker.Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:alpine AS builder
 
+ENV PORT=50051
+
 COPY broker /broker
 
 RUN cd /broker && go mod download
@@ -8,5 +10,7 @@ RUN cd /broker && go build .
 FROM alpine:3 AS broker
 
 COPY --from=builder /broker/dagorama /broker
+COPY broker.entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/broker"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["broker"]

--- a/broker.entrypoint.sh
+++ b/broker.entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/ash -e
+
+if [ "$1" = "broker" ]; then
+    exec /broker --port $PORT
+else
+    exec "$@"
+fi

--- a/dagorama/definition.py
+++ b/dagorama/definition.py
@@ -5,6 +5,7 @@ from inspect import isawaitable, ismethod
 from pickle import loads
 from typing import Any, Awaitable, cast
 from uuid import UUID, uuid4
+from os import getenv
 
 import grpc
 
@@ -78,9 +79,11 @@ class DAGInstance:
 
 @contextmanager
 def dagorama_context():
-    # TODO: Get global context otherwise creates it
+    host = getenv("DAGORAMA_HOST", "localhost")
+    port = getenv("DAGORAMA_PORT", "50051")
 
-    with grpc.insecure_channel("localhost:50051") as channel:
+    # TODO: Get global context otherwise creates it
+    with grpc.insecure_channel(f"{host}:{port}") as channel:
         yield pb2_grpc.DagoramaStub(channel)
 
 


### PR DESCRIPTION
Add docker broker and worker environment parameters to allow for port and host customization of the broker location. This is motivated by the docker use-case when we want to override networking configuration to point to `host.docker.internal`.