### PR TITLE
Switch verbose logging to debug-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ def main():
         task_definition = MyTask()
         instance, promise = task_definition()
 
-        with launch_workers(4):
-            sleep(3)
+        with launch_workers(4, exit_on_completion=True) as workers:
+            # Wait for each to quit
+            for worker in workers:
+                worker.join()
         response = resolve(instance, promise)
         end = time() 
 

--- a/dagorama/cli.py
+++ b/dagorama/cli.py
@@ -1,6 +1,6 @@
 from click import command, option
 
-from dagorama.runner import execute
+from dagorama.runner import execute_worker
 
 
 @command()
@@ -8,7 +8,7 @@ from dagorama.runner import execute
 @option("--include-queue", multiple=True)
 @option("--toleration", multiple=True)
 def worker(exclude_queue: list[str], include_queue: list[str], toleration: list[str]):
-    execute(
+    execute_worker(
         exclude_queues=exclude_queue,
         include_queues=include_queue,
         queue_tolerations=toleration,

--- a/dagorama/logging.py
+++ b/dagorama/logging.py
@@ -1,0 +1,17 @@
+from logging import getLogger, basicConfig
+from os import getenv
+
+LOGGER = getLogger("Dagorama")
+
+basicConfig(
+    level=getenv("DAGORAMA_LOG_LEVEL", "WARNING"),
+    format="{asctime} - {name} - [{levelname}] - {message}",
+)
+
+def get_default_console_width(default_value: int = 80):
+   try:
+      from os import get_terminal_size
+      return get_terminal_size().columns
+   except Exception:
+      # Likely not running in a terminal
+      return default_value

--- a/dagorama/tests/test_decorators.py
+++ b/dagorama/tests/test_decorators.py
@@ -3,7 +3,7 @@ import pytest
 from dagorama.decorators import dagorama
 from dagorama.definition import DAGDefinition, resolve
 from dagorama.retry import ExponentialRetry, StaticRetry
-from dagorama.runner import execute, execute_async
+from dagorama.runner import execute_worker, execute_worker_async
 
 
 class CustomNameDag(DAGDefinition):
@@ -64,7 +64,7 @@ def test_custom_name(broker):
     dag_instance, dag_result = dag()
 
     # Should run this queue
-    execute(
+    execute_worker(
         include_queues=["test_queue"],
         infinite_loop=False,
         catch_exceptions=False,
@@ -75,7 +75,7 @@ def test_custom_name(broker):
     dag_instance, dag_result = dag()
 
     # Should not run this queue
-    execute(
+    execute_worker(
         include_queues=["test_queue_2"],
         infinite_loop=False,
         catch_exceptions=False,
@@ -89,7 +89,7 @@ async def test_async(broker):
     dag_instance, dag_result = await dag()
 
     # Should run this queue
-    await execute_async(
+    await execute_worker_async(
         include_queues=["test_queue"],
         infinite_loop=False,
         catch_exceptions=False,
@@ -102,11 +102,11 @@ def test_taint_name(broker):
     dag_instance, dag_result = dag()
 
     # Should not run a tained queue by default
-    execute(infinite_loop=False, catch_exceptions=False)
+    execute_worker(infinite_loop=False, catch_exceptions=False)
     assert resolve(dag_instance, dag_result) == None
 
     # Require specific allowance
-    execute(queue_tolerations=["test_taint"], infinite_loop=False, catch_exceptions=False)
+    execute_worker(queue_tolerations=["test_taint"], infinite_loop=False, catch_exceptions=False)
     assert resolve(dag_instance, dag_result) == 10
 
 
@@ -116,7 +116,7 @@ def test_erroring_dags(broker, dag_class):
     dag_instance, dag_result = dag()
 
     # Should not run a tained queue by default
-    execute(infinite_loop=False, catch_exceptions=True)
+    execute_worker(infinite_loop=False, catch_exceptions=True)
     assert resolve(dag_instance, dag_result) == None
 
 
@@ -127,5 +127,5 @@ def test_custom_third_party_dag(broker):
     dag = CustomThirdPartyDag()
     dag_instance, dag_result = dag()
 
-    execute(infinite_loop=False, catch_exceptions=True)
+    execute_worker(infinite_loop=False, catch_exceptions=True)
     assert resolve(dag_instance, dag_result) == 1

--- a/dagorama/tests/test_definition.py
+++ b/dagorama/tests/test_definition.py
@@ -1,7 +1,7 @@
 from dagorama.decorators import dagorama
 from dagorama.definition import (DAGDefinition, DAGInstance,
                                  generate_instance_id)
-from dagorama.runner import execute
+from dagorama.runner import execute_worker
 
 
 class SampleDefinition(DAGDefinition):
@@ -23,4 +23,4 @@ def test_instance_injection(broker):
     instance = DAGInstance(generate_instance_id(), definition)
     instance.entrypoint()
 
-    execute(infinite_loop=False, catch_exceptions=False)
+    execute_worker(infinite_loop=False, catch_exceptions=False)

--- a/dagorama/tests/test_runner.py
+++ b/dagorama/tests/test_runner.py
@@ -2,7 +2,7 @@ from inspect import getfullargspec
 
 from dagorama.decorators import dagorama
 from dagorama.definition import DAGDefinition, resolve
-from dagorama.runner import execute, execute_async
+from dagorama.runner import execute_worker, execute_worker_async
 from dagorama.serializer import register_definition
 
 
@@ -26,7 +26,7 @@ def test_runner_custom_init(broker):
     dag_instance, dag_result = dag()
 
     register_definition(dag)
-    execute(infinite_loop=False, catch_exceptions=False)
+    execute_worker(infinite_loop=False, catch_exceptions=False)
 
     assert resolve(dag_instance, dag_result) == 10
 
@@ -36,6 +36,6 @@ def test_sync_async_parity():
     Ensure the sync and async runner functions have the same API.
 
     """
-    sync_spec = getfullargspec(execute)
-    async_spec = getfullargspec(execute_async)
+    sync_spec = getfullargspec(execute_worker)
+    async_spec = getfullargspec(execute_worker_async)
     assert sync_spec.args == async_spec.args

--- a/dagorama/tests/test_sample_dag.py
+++ b/dagorama/tests/test_sample_dag.py
@@ -4,7 +4,7 @@ import pytest
 
 from dagorama.decorators import dagorama
 from dagorama.definition import DAGDefinition, resolve
-from dagorama.runner import CodeMismatchException, execute
+from dagorama.runner import CodeMismatchException, execute_worker
 
 
 class CustomDag(DAGDefinition):
@@ -62,7 +62,7 @@ def test_sample_dag_1(broker):
     dag = CustomDag()
     dag_instance, dag_result = dag(1)
 
-    execute(infinite_loop=False, catch_exceptions=False)
+    execute_worker(infinite_loop=False, catch_exceptions=False)
 
     assert resolve(dag_instance, dag_result) == 9
 
@@ -75,4 +75,4 @@ def test_sample_dag_worker_code_mismatch(broker):
 
     with modify_entrypoint_signature():
         with pytest.raises(CodeMismatchException):
-            execute(infinite_loop=False, catch_exceptions=False)
+            execute_worker(infinite_loop=False, catch_exceptions=False)


### PR DESCRIPTION
Switch most per-task logging to debug-level, to avoid polluting prod logs.