### PR TITLE
Add file-based daemon reload

### DIFF
--- a/dagorama/hot_reload.py
+++ b/dagorama/hot_reload.py
@@ -1,0 +1,58 @@
+import time
+from subprocess import Popen
+
+from click import command, secho, option
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+
+class EventHandler(FileSystemEventHandler):
+    def __init__(self):
+        super().__init__()
+
+        # Bootup an initial version before files change
+        self.current_worker = self.new_worker()
+
+    def dispatch(self, event):
+        if event.event_type not in {"modified", "created"}:
+            return None
+
+        if self.current_worker:
+            self.current_worker.terminate()
+            self.current_worker = None
+
+        self.current_worker = self.new_worker()
+        secho(
+            f"[{time.asctime()}] noticed: [{event.event_type}] on: [{event.src_path}]",
+            fg="blue",
+        )
+
+    def new_worker(self):
+        return Popen(
+            "echo 'Rebooting worker...' && poetry run worker",
+            shell=True
+        )
+
+
+@command()
+@option("--watch-dir", default=".", help="Directory to watch for changes")
+def run_hot_reload_worker(watch_dir):
+    """
+    Run the dagorama worker, listening to changes in a directory. This should just be
+    used for development purposes.
+
+    """
+    secho(f"Launching a dagorama worker in hot-reload mode. This is only intended for development purposes.", fg="yellow")
+
+    event_handler = EventHandler()
+
+    observer = Observer()
+    observer.schedule(event_handler, watch_dir, recursive=True)
+    observer.start()
+
+    try:
+        while True:
+            time.sleep(1)
+    finally:
+        observer.stop()
+        observer.join()

--- a/dagorama/logging.py
+++ b/dagorama/logging.py
@@ -1,5 +1,5 @@
-from logging import (CRITICAL, DEBUG, ERROR, INFO, WARNING, basicConfig,
-                     getLogger, StreamHandler, Formatter)
+from logging import (CRITICAL, DEBUG, ERROR, INFO, WARNING, Formatter,
+                     StreamHandler, basicConfig, getLogger)
 from os import getenv
 
 

--- a/dagorama/runner.py
+++ b/dagorama/runner.py
@@ -14,7 +14,7 @@ import dagorama.api.api_pb2_grpc as pb2_grpc
 from dagorama.code_signature import calculate_function_hash
 from dagorama.definition import dagorama_context
 from dagorama.inspection import resolve_promises
-from dagorama.logging import get_logger, get_default_console_width
+from dagorama.logging import get_default_console_width, get_logger
 from dagorama.models.arguments import DAGArguments
 from dagorama.serializer import name_to_function
 

--- a/dagorama/tests/test_hot_reload.py
+++ b/dagorama/tests/test_hot_reload.py
@@ -1,0 +1,90 @@
+import pytest
+from unittest.mock import MagicMock, call
+from subprocess import Popen
+from watchdog.events import FileSystemEvent
+from dagorama.hot_reload import EventHandler, Observer, run_hot_reload_worker
+from unittest.mock import ANY, patch
+from click.testing import CliRunner
+from time import sleep
+
+REBOOT_COMMAND = "echo 'Rebooting worker...' && poetry run worker"
+
+def test_dispatch():
+    event = MagicMock(spec=FileSystemEvent)
+    event.event_type = "modified"
+    Popen_mock = MagicMock(spec=Popen)
+
+    with patch("dagorama.hot_reload.Popen", new=Popen_mock):
+        handler = EventHandler()
+        handler.current_worker = Popen_mock.return_value
+        handler.dispatch(event)
+
+        # Assert that the current_worker has been terminated and a new one has been created
+        assert Popen_mock.return_value.terminate.call_args_list == [call()]
+        assert Popen_mock.call_args_list == [call(REBOOT_COMMAND, shell=True), call(REBOOT_COMMAND, shell=True)]
+
+def test_new_worker():
+    Popen_mock = MagicMock(spec=Popen)
+
+    with patch("dagorama.hot_reload.Popen", new=Popen_mock):
+        handler = EventHandler()
+
+        # Should boot up and auto-init a new worker
+        assert Popen_mock.call_args_list == [call(REBOOT_COMMAND, shell=True)]
+
+        worker = handler.new_worker()
+
+        # Assert that a new process has been created
+        # One on init and one on dispatch
+        assert worker == Popen_mock.return_value
+        assert Popen_mock.call_args_list == [
+            call(REBOOT_COMMAND, shell=True),
+            call(REBOOT_COMMAND, shell=True)
+        ]
+
+def test_run_hot_reload_worker():
+    Observer_mock = MagicMock(spec=Observer)
+
+    with patch("dagorama.hot_reload.Observer", new=Observer_mock), patch("time.sleep", side_effect=Exception("Stop loop")):
+        runner = CliRunner()
+        result = runner.invoke(run_hot_reload_worker, ["--watch-dir", "TEST_DIR"])
+
+        # Assert that an observer has been set up and started
+        assert Observer_mock.return_value.schedule.call_args_list == [call(ANY, "TEST_DIR", recursive=True)]
+        assert Observer_mock.return_value.start.call_args_list == [call()]
+
+        # Assert that there was an exception raised to stop the loop
+        assert result.exit_code == 1
+        assert "Stop loop" in str(result.exception)
+
+def test_file_creation_triggers_dispatch(tmp_path):
+    # Mocking Popen
+    Popen_mock = MagicMock(spec=Popen)
+
+    with patch('dagorama.hot_reload.Popen', new=Popen_mock):
+        handler = EventHandler()
+
+        # Setup observer for the temporary directory
+        observer = Observer()
+        observer.schedule(handler, str(tmp_path), recursive=True)
+        observer.start()
+
+        # Create a new file in the temporary directory
+        new_file = tmp_path / "new_file.txt"
+        new_file.write_text("Hello, World!")
+
+        # Sleep for a moment to let the observer detect the file change
+        sleep(1)
+
+        # Assert that the current_worker has been terminated and a new one has been created
+        # One alert for the initial file creation, one for folder modification, and one for the file modification
+        # We mostly care that it got more than one alert
+        reboot_count = len(Popen_mock.return_value.terminate.call_args_list)
+        assert reboot_count >= 1
+        # Initial launch plus reboots
+        assert Popen_mock.call_args_list == [
+            call(REBOOT_COMMAND, shell=True)
+        ] * (reboot_count+1)
+
+        observer.stop()
+        observer.join()

--- a/dagorama/tests/test_logging.py
+++ b/dagorama/tests/test_logging.py
@@ -1,7 +1,8 @@
 from os import environ
-from dagorama.logging import get_logger
+
 import pytest
 
+from dagorama.logging import get_logger
 
 # Logs should occur in ascending order
 LOG_PRIORITY = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -269,10 +269,21 @@ category = "dev"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "watchdog"
+version = "3.0.0"
+description = "Filesystem events monitoring"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "91a293ba606559ebe5652517c83a9a90bb789dc0f9947c349241266fe422b538"
+content-hash = "8d3432233e4c8e83feadbca1dff5cf36ca0d1c1066d4c63ae9c529e33c09ca17"
 
 [metadata.files]
 attrs = [
@@ -490,4 +501,33 @@ types-setuptools = [
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
     {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+watchdog = [
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:336adfc6f5cc4e037d52db31194f7581ff744b67382eb6021c868322e32eef41"},
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a70a8dcde91be523c35b2bf96196edc5730edb347e374c7de7cd20c43ed95397"},
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:adfdeab2da79ea2f76f87eb42a3ab1966a5313e5a69a0213a3cc06ef692b0e96"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b57a1e730af3156d13b7fdddfc23dea6487fceca29fc75c5a868beed29177ae"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7ade88d0d778b1b222adebcc0927428f883db07017618a5e684fd03b83342bd9"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7e447d172af52ad204d19982739aa2346245cc5ba6f579d16dac4bfec226d2e7"},
+    {file = "watchdog-3.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9fac43a7466eb73e64a9940ac9ed6369baa39b3bf221ae23493a9ec4d0022674"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8ae9cda41fa114e28faf86cb137d751a17ffd0316d1c34ccf2235e8a84365c7f"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:25f70b4aa53bd743729c7475d7ec41093a580528b100e9a8c5b5efe8899592fc"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4f94069eb16657d2c6faada4624c39464f65c05606af50bb7902e036e3219be3"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7c5f84b5194c24dd573fa6472685b2a27cc5a17fe5f7b6fd40345378ca6812e3"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3aa7f6a12e831ddfe78cdd4f8996af9cf334fd6346531b16cec61c3b3c0d8da0"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:233b5817932685d39a7896b1090353fc8efc1ef99c9c054e46c8002561252fb8"},
+    {file = "watchdog-3.0.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:13bbbb462ee42ec3c5723e1205be8ced776f05b100e4737518c67c8325cf6100"},
+    {file = "watchdog-3.0.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8f3ceecd20d71067c7fd4c9e832d4e22584318983cabc013dbf3f70ea95de346"},
+    {file = "watchdog-3.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c9d8c8ec7efb887333cf71e328e39cffbf771d8f8f95d308ea4125bf5f90ba64"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0e06ab8858a76e1219e68c7573dfeba9dd1c0219476c5a44d5333b01d7e1743a"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:d00e6be486affb5781468457b21a6cbe848c33ef43f9ea4a73b4882e5f188a44"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:c07253088265c363d1ddf4b3cdb808d59a0468ecd017770ed716991620b8f77a"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:5113334cf8cf0ac8cd45e1f8309a603291b614191c9add34d33075727a967709"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:51f90f73b4697bac9c9a78394c3acbbd331ccd3655c11be1a15ae6fe289a8c83"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:ba07e92756c97e3aca0912b5cbc4e5ad802f4557212788e72a72a47ff376950d"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:d429c2430c93b7903914e4db9a966c7f2b068dd2ebdd2fa9b9ce094c7d459f33"},
+    {file = "watchdog-3.0.0-py3-none-win32.whl", hash = "sha256:3ed7c71a9dccfe838c2f0b6314ed0d9b22e77d268c67e015450a29036a81f60f"},
+    {file = "watchdog-3.0.0-py3-none-win_amd64.whl", hash = "sha256:4c9956d27be0bb08fc5f30d9d0179a855436e655f046d288e2bcc11adfae893c"},
+    {file = "watchdog-3.0.0-py3-none-win_ia64.whl", hash = "sha256:5d9f3a10e02d7371cd929b5d8f11e87d4bad890212ed3901f9b4d68767bee759"},
+    {file = "watchdog-3.0.0.tar.gz", hash = "sha256:4d98a320595da7a7c5a18fc48cb633c2e73cda78f93cac2ef42d42bf609a33f9"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.10"
 grpcio = "^1.50.0"
 click = "^8.1.3"
 protobuf = "^4.21.9"
+watchdog = "^3.0.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -29,3 +30,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 worker = "dagorama.cli:worker"
+worker-hot-reload = "dagorama.hot_reload:run_hot_reload_worker"


### PR DESCRIPTION
Most web services (flask, fastapi, etc) will autoreload their environment when it detects a file changing during development. This is helpful to immediately interact with the current codebase without having to kill the current application and reload.

This was historically a bit hard to do in dagorama and required an external script to listen for changes and then reload the worker. Here we add a simple hot reloader that will perform this same action. It can be invoked via `poetry run worker-hot-reload`, much like the standard worker utility.